### PR TITLE
Consistent stockstash labels and title fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # stockstash
 > A stock portfolio web application built with Flask.
 
-Stockstash is a Flask application ideal for the individual investor. This application allows users to track their own customizable stock market portfolio and watchlist. The application will utilize RESTful web services to call current and historical stock data and a databased backed system to track profile changes and updates.
+stockstash is a Flask application ideal for the individual investor. This application allows users to track their own customizable stock market portfolio and watchlist. The application will utilize RESTful web services to call current and historical stock data and a databased backed system to track profile changes and updates.
 
 ### Compile / Run Instructions
 Run the following commands in the root project directory.

--- a/stockstash/routes.py
+++ b/stockstash/routes.py
@@ -10,7 +10,7 @@ import json
 
 @app.route("/")
 def index():
-    return render_template('home.html', title='Stockstash')
+    return render_template('home.html', title='stockstash')
 
 # login route
 @app.route("/login", methods=['GET', 'POST'])
@@ -63,7 +63,7 @@ def register():
                     fname=form.fname.data, lname=form.lname.data,
                     brokerage=form.brokerage.data, portfolio=[], watchlist=[])
         user.save()
-        flash(f'Welcome to StockStash {form.fname.data}! '
+        flash(f'Welcome to stockstash {form.fname.data}! '
               f'\nPlease login with your new account.', 'success')
         return redirect(url_for('login'))
     return render_template('register.html', title='Register', form=form)

--- a/stockstash/routes.py
+++ b/stockstash/routes.py
@@ -10,7 +10,7 @@ import json
 
 @app.route("/")
 def index():
-    return render_template('home.html', title='stockstash')
+    return render_template('home.html')
 
 # login route
 @app.route("/login", methods=['GET', 'POST'])

--- a/stockstash/templates/admin.html
+++ b/stockstash/templates/admin.html
@@ -95,7 +95,7 @@
     </div>
     <div class="border-top pt-4">
         <small class="text-muted">
-            Stockstash
+            stockstash
         </small>
     </div>
 {% endblock content %}

--- a/stockstash/templates/register.html
+++ b/stockstash/templates/register.html
@@ -6,7 +6,7 @@
             {{ form.hidden_tag() }}
 
             <fieldset class="form-group">
-                <legend class="border-bottom mb-3">Join StockStash</legend>
+                <legend class="border-bottom mb-3">Join stockstash</legend>
                 <div class="form-group">
 
                     <!-- username field is email -->


### PR DESCRIPTION
1) Located all 'stockstash' labels and updated them to have uniform/consistent styling
2) Removed redundant stockstash title from home page. 
Ex:
prev - 'stockstash - stockstash'
curr - 'stockstash'